### PR TITLE
Info about aggregation types

### DIFF
--- a/cloud_integrations_add_gcp.md
+++ b/cloud_integrations_add_gcp.md
@@ -18,6 +18,27 @@ To register a Google Cloud Platform integration:
     
     For example, to monitor all the CPU metrics coming from the Compute Engine, enter <code>^gcp.compute.instance.cpu.*$</code>.
     
+   <strong>Note:</strong>Metric names consist of the actual metric name and a suffix (starting with an underscore ("_") or a dot (".")). The suffix represents an aggregation type. In the regular expression, you must use the actual metric names without the aggregation types, such as: <code>count</code>, <code>rate</code>, <code>min</code>, <code>max</code>, <code>sumOfSquaredDeviation</code>, <code>mean</code>, and so on.
+
+   For example, for the Google Cloud Pub/Sub Engine, we collect a number of metrics, and some of them, contain a suffix:
+
+   Push request latencies metrics:
+
+    * <code>gcp.pubsub.subscription.push_request_latencies.bucket</code>
+    * <code>gcp.pubsub.subscription.push_request_latencies.count</code>
+    * <code>gcp.pubsub.subscription.push_request_latencies.mean</code>
+    * <code>gcp.pubsub.subscription.push_request_latencies.sumOfSquaredDeviation</code>
+   
+   Here, the actual metric name is <code>gcp.pubsub.subscription.push_request_latencies</code>, while <code>bucket</code>, <code>count</code>, <code>mean</code>, and <code>sumOfSquaredDeviation</code> are the aggregation types. When you create the regular expression, you must use only <code>gcp.pubsub.subscription.push_request_latencies</code>. For example, <code>^gcp.pubsub.subscription.push_request_latencies$</code>.
+
+
+   Cumulative count of messages acknowledged by Acknowledge requests, grouped by delivery type.
+   
+    * <code>gcp.pubsub.subscription.ack_message_count_count</code>
+    * <code>gcp.pubsub.subscription.ack_message_count_rate</code>
+
+   Here, the actual metric name is <code>gcp.pubsub.subscription.ack_message_count</code>, while <code>_count</code> and <code>_rate</code> are the aggregation types. When you create the regular expression, you must use only <code>gcp.pubsub.subscription.ack_message_count</code>. For example, <code>^gcp.pubsub.subscription.ack_message_count$</code>.
+
 5. (Optional) In the **Additional Metric Prefixes** text box, enter a comma separated list of additional metrics prefixes. 
    The metrics names that start with these prefixes will be imported in addition to what you have selected as categories.
 6. (Optional) Change the **Service Refresh Rate**. The default is `5` minutes.

--- a/cloud_integrations_add_gcp.md
+++ b/cloud_integrations_add_gcp.md
@@ -32,7 +32,7 @@ To register a Google Cloud Platform integration:
    Here, the actual metric name is <code>gcp.pubsub.subscription.push_request_latencies</code>, while <code>bucket</code>, <code>count</code>, <code>mean</code>, and <code>sumOfSquaredDeviation</code> are the aggregation types. When you create the regular expression, you must use only <code>gcp.pubsub.subscription.push_request_latencies</code>. For example, <code>^gcp.pubsub.subscription.push_request_latencies$</code>.
 
 
-   Cumulative count of messages acknowledged by Acknowledge requests, grouped by delivery type.
+   Cumulative count of messages acknowledged by Acknowledge requests, grouped by delivery type:
    
     * <code>gcp.pubsub.subscription.ack_message_count_count</code>
     * <code>gcp.pubsub.subscription.ack_message_count_rate</code>

--- a/cloud_integrations_add_gcp.md
+++ b/cloud_integrations_add_gcp.md
@@ -18,7 +18,7 @@ To register a Google Cloud Platform integration:
     
     For example, to monitor all the CPU metrics coming from the Compute Engine, enter <code>^gcp.compute.instance.cpu.*$</code>.
     
-   <strong>Note:</strong>Metric names consist of the actual metric name and a suffix (starting with an underscore ("_") or a dot (".")). The suffix represents an aggregation type. In the regular expression, you must use the actual metric names without the aggregation types, such as: <code>count</code>, <code>rate</code>, <code>min</code>, <code>max</code>, <code>sumOfSquaredDeviation</code>, <code>mean</code>, and so on.
+   <strong>Note:</strong> Metric names consist of the actual metric name and a suffix (starting with an underscore ("_") or a dot (".")). The suffix represents an aggregation type. In the regular expression, you must use the actual metric names without the aggregation types, such as: <code>count</code>, <code>rate</code>, <code>min</code>, <code>max</code>, <code>sumOfSquaredDeviation</code>, <code>mean</code>, and so on.
 
    For example, for the Google Cloud Pub/Sub Engine, we collect a number of metrics, and some of them, contain a suffix:
 


### PR DESCRIPTION
Aggregation types are added as a suffix to some metrics. Added examples for GCP.